### PR TITLE
Make global tags an d namespace methods

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -1,0 +1,40 @@
+package dogstatsd
+
+import (
+	old "github.com/ooyala/go-dogstatsd"
+	"testing"
+)
+
+var myTags = []string{"a", "b", "c"}
+
+func BenchmarkNewSet(b *testing.B) {
+	c, _ := New("localhost:9421") // probably unused
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Set("test", "item", myTags, 0.9999)
+	}
+}
+
+func BenchmarkOldSet(b *testing.B) {
+	c, _ := old.New("localhost:9421") // probably unused
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Set("test", "item", myTags, 0.9999)
+	}
+}
+
+func BenchmarkNewGauge(b *testing.B) {
+	c, _ := New("localhost:9421") // probably unused
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Gauge("test", 1.23412, myTags, 0.9999)
+	}
+}
+
+func BenchmarkOldGauge(b *testing.B) {
+	c, _ := old.New("localhost:9421") // probably unused
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Gauge("test", 1.23412, myTags, 0.9999)
+	}
+}

--- a/dog/dog.go
+++ b/dog/dog.go
@@ -1,0 +1,34 @@
+package dog
+
+import "github.com/Shopify/go-dogstatsd"
+
+var Client *dogstatsd.Client
+
+// Configure instantiates the global client.
+func Configure(addr string, namespace string, tags []string) (err error) {
+	if Client, err = dogstatsd.New(addr); err != nil {
+		return
+	}
+	Client.Namespace = namespace
+	Client.Tags = tags
+	return
+}
+
+func Event(title string, text string, tags []string) error {
+	return Client.Event(title, text, tags)
+}
+func Gauge(name string, value float64, tags []string, rate float64) error {
+	return Client.Gauge(name, value, tags, rate)
+}
+func Count(name string, value int64, tags []string, rate float64) error {
+	return Client.Count(name, value, tags, rate)
+}
+func Histogram(name string, value float64, tags []string, rate float64) error {
+	return Client.Histogram(name, value, tags, rate)
+}
+func Timer(name string, value float64, tags []string, rate float64) error {
+	return Client.Timer(name, value, tags, rate)
+}
+func Set(name string, value string, tags []string, rate float64) error {
+	return Client.Set(name, value, tags, rate)
+}

--- a/dog/dog.go
+++ b/dog/dog.go
@@ -1,6 +1,9 @@
 package dog
 
-import "github.com/Shopify/go-dogstatsd"
+import (
+	"errors"
+	"github.com/Shopify/go-dogstatsd"
+)
 
 var Client *dogstatsd.Client
 
@@ -14,21 +17,46 @@ func Configure(addr string, namespace string, tags []string) (err error) {
 	return
 }
 
+var ErrUnconfigured = errors.New("connection has not been configured; call dog.Configure()")
+
 func Event(title string, text string, tags []string) error {
+	if Client == nil {
+		return ErrUnconfigured
+	}
 	return Client.Event(title, text, tags)
 }
+
 func Gauge(name string, value float64, tags []string, rate float64) error {
+	if Client == nil {
+		return ErrUnconfigured
+	}
 	return Client.Gauge(name, value, tags, rate)
 }
+
 func Count(name string, value int64, tags []string, rate float64) error {
+	if Client == nil {
+		return ErrUnconfigured
+	}
 	return Client.Count(name, value, tags, rate)
 }
+
 func Histogram(name string, value float64, tags []string, rate float64) error {
+	if Client == nil {
+		return ErrUnconfigured
+	}
 	return Client.Histogram(name, value, tags, rate)
 }
+
 func Timer(name string, value float64, tags []string, rate float64) error {
+	if Client == nil {
+		return ErrUnconfigured
+	}
 	return Client.Timer(name, value, tags, rate)
 }
+
 func Set(name string, value string, tags []string, rate float64) error {
+	if Client == nil {
+		return ErrUnconfigured
+	}
 	return Client.Set(name, value, tags, rate)
 }

--- a/dogstatsd.go
+++ b/dogstatsd.go
@@ -26,7 +26,19 @@ import (
 	"fmt"
 	"math/rand"
 	"net"
-	"strings"
+	"strconv"
+)
+
+var (
+	MetricSeparator = []byte{':'}
+	RateSeparator   = []byte("|@")
+	TagSeparator    = []byte("|#")
+	GaugeSpec       = []byte("|g")
+	CountSpec       = []byte("|c")
+	HistogramSpec   = []byte("|h")
+	TimerSpec       = []byte("|ms")
+	SetSpec         = []byte("|s")
+	Comma           = []byte{','}
 )
 
 // Client holds onto a connection and the other context necessary for every stasd packet.
@@ -55,26 +67,46 @@ func (c *Client) Close() error {
 }
 
 // send handles sampling and sends the message over UDP. It also adds global namespace prefixes and tags.
-func (c *Client) send(name string, value string, tags []string, rate float64) error {
+func (c *Client) send(b *bytes.Buffer, spec []byte, tags []string, rate float64) error {
+	if _, err := b.Write(spec); err != nil {
+		return err
+	}
+
 	if rate < 1 {
 		if rand.Float64() < rate {
-			value = fmt.Sprintf("%s|@%f", value, rate)
+			if _, err := b.Write(RateSeparator); err != nil {
+				return err
+			}
+			/*
+				bs := b.Bytes()
+				bs = strconv.AppendFloat(bs, rate, 'f', -1, 64)
+				b = bytes.NewBuffer(bs)
+			*/
+			b.WriteString(strconv.FormatFloat(rate, 'f', -1, 64))
 		} else {
 			return nil
 		}
 	}
 
-	if c.Namespace != "" {
-		name = fmt.Sprintf("%s%s", c.Namespace, name)
-	}
-
 	tags = append(c.Tags, tags...)
 	if len(tags) > 0 {
-		value = fmt.Sprintf("%s|#%s", value, strings.Join(tags, ","))
+		if _, err := b.Write(TagSeparator); err != nil {
+			return err
+		}
+		l := len(tags) - 1
+		for i, t := range tags {
+			if _, err := b.WriteString(t); err != nil {
+				return err
+			}
+			if i != l {
+				if _, err := b.Write(Comma); err != nil {
+					return err
+				}
+			}
+		}
 	}
 
-	data := fmt.Sprintf("%s:%s", name, value)
-	_, err := c.conn.Write([]byte(data))
+	_, err := c.conn.Write(b.Bytes())
 	return err
 }
 
@@ -94,32 +126,76 @@ func (c *Client) Event(title string, text string, tags []string) error {
 	return err
 }
 
+func (c *Client) start(b *bytes.Buffer, name string) error {
+	var err error
+	if _, err = b.WriteString(c.Namespace); err != nil {
+		return err
+	}
+	if _, err = b.WriteString(name); err != nil {
+		return err
+	}
+	if _, err = b.Write(MetricSeparator); err != nil {
+		return err
+	}
+	return nil
+}
+
 // Gauge measures the value of a metric at a particular time
 func (c *Client) Gauge(name string, value float64, tags []string, rate float64) error {
-	stat := fmt.Sprintf("%f|g", value)
-	return c.send(name, stat, tags, rate)
+	var b bytes.Buffer
+	if err := c.start(&b, name); err != nil {
+		return err
+	}
+	if _, err := b.WriteString(strconv.FormatFloat(value, 'f', -1, 64)); err != nil {
+		return err
+	}
+	return c.send(&b, GaugeSpec, tags, rate)
 }
 
 // Count tracks how many times something happened per second
 func (c *Client) Count(name string, value int64, tags []string, rate float64) error {
-	stat := fmt.Sprintf("%d|c", value)
-	return c.send(name, stat, tags, rate)
+	var b bytes.Buffer
+	if err := c.start(&b, name); err != nil {
+		return err
+	}
+	if _, err := b.WriteString(strconv.FormatInt(value, 10)); err != nil {
+		return err
+	}
+	return c.send(&b, CountSpec, tags, rate)
 }
 
 // Histogram tracks the statistical distribution of a set of values
 func (c *Client) Histogram(name string, value float64, tags []string, rate float64) error {
-	stat := fmt.Sprintf("%f|h", value)
-	return c.send(name, stat, tags, rate)
+	var b bytes.Buffer
+	if err := c.start(&b, name); err != nil {
+		return err
+	}
+	if _, err := b.WriteString(strconv.FormatFloat(value, 'f', -1, 64)); err != nil {
+		return err
+	}
+	return c.send(&b, HistogramSpec, tags, rate)
 }
 
 // Timer tracks the statistical distribution of a set of durations
 func (c *Client) Timer(name string, value float64, tags []string, rate float64) error {
-	stat := fmt.Sprintf("%f|ms", value)
-	return c.send(name, stat, tags, rate)
+	var b bytes.Buffer
+	if err := c.start(&b, name); err != nil {
+		return err
+	}
+	if _, err := b.WriteString(strconv.FormatFloat(value, 'f', -1, 64)); err != nil {
+		return err
+	}
+	return c.send(&b, TimerSpec, tags, rate)
 }
 
 // Set counts the number of unique elements in a group
 func (c *Client) Set(name string, value string, tags []string, rate float64) error {
-	stat := fmt.Sprintf("%s|s", value)
-	return c.send(name, stat, tags, rate)
+	var b bytes.Buffer
+	if err := c.start(&b, name); err != nil {
+		return err
+	}
+	if _, err := b.WriteString(value); err != nil {
+		return err
+	}
+	return c.send(&b, SetSpec, tags, rate)
 }

--- a/dogstatsd.go
+++ b/dogstatsd.go
@@ -30,15 +30,15 @@ import (
 )
 
 var (
-	MetricSeparator = []byte{':'}
-	RateSeparator   = []byte("|@")
-	TagSeparator    = []byte("|#")
-	GaugeSpec       = []byte("|g")
-	CountSpec       = []byte("|c")
-	HistogramSpec   = []byte("|h")
-	TimerSpec       = []byte("|ms")
-	SetSpec         = []byte("|s")
-	Comma           = []byte{','}
+	metricSeparator = []byte{':'}
+	rateSeparator   = []byte("|@")
+	tagSeparator    = []byte("|#")
+	gaugeSpec       = []byte("|g")
+	countSpec       = []byte("|c")
+	histogramSpec   = []byte("|h")
+	timerSpec       = []byte("|ms")
+	setSpec         = []byte("|s")
+	comma           = []byte{','}
 )
 
 // Client holds onto a connection and the other context necessary for every stasd packet.
@@ -74,14 +74,9 @@ func (c *Client) send(b *bytes.Buffer, spec []byte, tags []string, rate float64)
 
 	if rate < 1 {
 		if rand.Float64() < rate {
-			if _, err := b.Write(RateSeparator); err != nil {
+			if _, err := b.Write(rateSeparator); err != nil {
 				return err
 			}
-			/*
-				bs := b.Bytes()
-				bs = strconv.AppendFloat(bs, rate, 'f', -1, 64)
-				b = bytes.NewBuffer(bs)
-			*/
 			b.WriteString(strconv.FormatFloat(rate, 'f', -1, 64))
 		} else {
 			return nil
@@ -90,7 +85,7 @@ func (c *Client) send(b *bytes.Buffer, spec []byte, tags []string, rate float64)
 
 	tags = append(c.Tags, tags...)
 	if len(tags) > 0 {
-		if _, err := b.Write(TagSeparator); err != nil {
+		if _, err := b.Write(tagSeparator); err != nil {
 			return err
 		}
 		l := len(tags) - 1
@@ -99,7 +94,7 @@ func (c *Client) send(b *bytes.Buffer, spec []byte, tags []string, rate float64)
 				return err
 			}
 			if i != l {
-				if _, err := b.Write(Comma); err != nil {
+				if _, err := b.Write(comma); err != nil {
 					return err
 				}
 			}
@@ -134,7 +129,7 @@ func (c *Client) start(b *bytes.Buffer, name string) error {
 	if _, err = b.WriteString(name); err != nil {
 		return err
 	}
-	if _, err = b.Write(MetricSeparator); err != nil {
+	if _, err = b.Write(metricSeparator); err != nil {
 		return err
 	}
 	return nil
@@ -149,7 +144,7 @@ func (c *Client) Gauge(name string, value float64, tags []string, rate float64) 
 	if _, err := b.WriteString(strconv.FormatFloat(value, 'f', -1, 64)); err != nil {
 		return err
 	}
-	return c.send(&b, GaugeSpec, tags, rate)
+	return c.send(&b, gaugeSpec, tags, rate)
 }
 
 // Count tracks how many times something happened per second
@@ -161,7 +156,7 @@ func (c *Client) Count(name string, value int64, tags []string, rate float64) er
 	if _, err := b.WriteString(strconv.FormatInt(value, 10)); err != nil {
 		return err
 	}
-	return c.send(&b, CountSpec, tags, rate)
+	return c.send(&b, countSpec, tags, rate)
 }
 
 // Histogram tracks the statistical distribution of a set of values
@@ -173,7 +168,7 @@ func (c *Client) Histogram(name string, value float64, tags []string, rate float
 	if _, err := b.WriteString(strconv.FormatFloat(value, 'f', -1, 64)); err != nil {
 		return err
 	}
-	return c.send(&b, HistogramSpec, tags, rate)
+	return c.send(&b, histogramSpec, tags, rate)
 }
 
 // Timer tracks the statistical distribution of a set of durations
@@ -185,7 +180,7 @@ func (c *Client) Timer(name string, value float64, tags []string, rate float64) 
 	if _, err := b.WriteString(strconv.FormatFloat(value, 'f', -1, 64)); err != nil {
 		return err
 	}
-	return c.send(&b, TimerSpec, tags, rate)
+	return c.send(&b, timerSpec, tags, rate)
 }
 
 // Set counts the number of unique elements in a group
@@ -197,5 +192,5 @@ func (c *Client) Set(name string, value string, tags []string, rate float64) err
 	if _, err := b.WriteString(value); err != nil {
 		return err
 	}
-	return c.send(&b, SetSpec, tags, rate)
+	return c.send(&b, setSpec, tags, rate)
 }

--- a/dogstatsd_test.go
+++ b/dogstatsd_test.go
@@ -18,14 +18,14 @@ var dogstatsdTests = []struct {
 	Rate            float64
 	Expected        string
 }{
-	{"", nil, "Gauge", "test.gauge", 1.0, nil, 1.0, "test.gauge:1.000000|g"},
-	{"", nil, "Gauge", "test.gauge", 1.0, nil, 0.999999, "test.gauge:1.000000|g|@0.999999"},
-	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA"}, 1.0, "test.gauge:1.000000|g|#tagA"},
-	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA", "tagB"}, 1.0, "test.gauge:1.000000|g|#tagA,tagB"},
-	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA"}, 0.999999, "test.gauge:1.000000|g|@0.999999|#tagA"},
+	{"", nil, "Gauge", "test.gauge", 1.0, nil, 1.0, "test.gauge:1|g"},
+	{"", nil, "Gauge", "test.gauge", 1.0, nil, 0.999999, "test.gauge:1|g|@0.999999"},
+	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA"}, 1.0, "test.gauge:1|g|#tagA"},
+	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA", "tagB"}, 1.0, "test.gauge:1|g|#tagA,tagB"},
+	{"", nil, "Gauge", "test.gauge", 1.0, []string{"tagA"}, 0.999999, "test.gauge:1|g|@0.999999|#tagA"},
 	{"", nil, "Count", "test.count", int64(1), []string{"tagA"}, 1.0, "test.count:1|c|#tagA"},
 	{"", nil, "Count", "test.count", int64(-1), []string{"tagA"}, 1.0, "test.count:-1|c|#tagA"},
-	{"", nil, "Histogram", "test.histogram", 2.3, []string{"tagA"}, 1.0, "test.histogram:2.300000|h|#tagA"},
+	{"", nil, "Histogram", "test.histogram", 2.3, []string{"tagA"}, 1.0, "test.histogram:2.3|h|#tagA"},
 	{"", nil, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "test.set:uuid|s|#tagA"},
 	{"flubber.", nil, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "flubber.test.set:uuid|s|#tagA"},
 	{"", []string{"tagC"}, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "test.set:uuid|s|#tagC,tagA"},

--- a/dogstatsd_test.go
+++ b/dogstatsd_test.go
@@ -6,6 +6,7 @@ import (
 	"net"
 	"reflect"
 	"testing"
+	"time"
 )
 
 var dogstatsdTests = []struct {
@@ -27,6 +28,7 @@ var dogstatsdTests = []struct {
 	{"", nil, "Count", "test.count", int64(-1), []string{"tagA"}, 1.0, "test.count:-1|c|#tagA"},
 	{"", nil, "Histogram", "test.histogram", 2.3, []string{"tagA"}, 1.0, "test.histogram:2.3|h|#tagA"},
 	{"", nil, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "test.set:uuid|s|#tagA"},
+	{"", nil, "Timer", "test.timer", 44876 * time.Microsecond, []string{"tagA"}, 1.0, "test.timer:44.876|ms|#tagA"},
 	{"flubber.", nil, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "flubber.test.set:uuid|s|#tagA"},
 	{"", []string{"tagC"}, "Set", "test.set", "uuid", []string{"tagA"}, 1.0, "test.set:uuid|s|#tagC,tagA"},
 }
@@ -43,8 +45,9 @@ func TestClient(t *testing.T) {
 	defer client.Close()
 
 	for _, tt := range dogstatsdTests {
-		client.Namespace = tt.GlobalNamespace
-		client.Tags = tt.GlobalTags
+		client.SetNamespace(tt.GlobalNamespace)
+		client.SetTags(tt.GlobalTags)
+
 		method := reflect.ValueOf(client).MethodByName(tt.Method)
 		e := method.Call([]reflect.Value{
 			reflect.ValueOf(tt.Metric),


### PR DESCRIPTION
- This way the Client can be replaced by an interface for dependency injection.
- Also, make the value of a timer a `time.Duration` to avoid confusion about what unit to use.

@burke @mkobetic
